### PR TITLE
Correct case for SagePayServiceProvider

### DIFF
--- a/src/SagePayServiceProvider.php
+++ b/src/SagePayServiceProvider.php
@@ -4,7 +4,7 @@ namespace Kofikwarteng\LaravelSagepay;
 
 use Illuminate\Support\ServiceProvider;
 
-class SagepayServiceProvider extends ServiceProvider
+class SagePayServiceProvider extends ServiceProvider
 {
     /**
      * Bootstrap the application services.


### PR DESCRIPTION
My production environment thrown a fatal error (worked on dev) due to the case mismatch.

You can either merge this request that corrects the name of the service provider or change the readme to include the correct class name as show below. 

``` php
Kofikwarteng\LaravelSagepay\SagepayServiceProvider::class
```

Thanks for the SagePay wrapper though, is saves me time on my current project. :+1:  
